### PR TITLE
Adds our own nextcloud image (based on fpm) and adds scripts to easily configure nextcloud in an extendable way

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,11 +3,11 @@
   enabled: true,
   dependencyDashboard: true,
   dependencyDashboardTitle: "🤖 Renovate Dashboard",
+  automerge: false,
 
   // People
-  assigneesFromCodeOwners: true,
-  reviewersFromCodeOwners: true,
   gitAuthor: "bugclerk <bugclerk@ixsystems.com>",
+  reviewers: ["stavros-k"],
 
   // Functionality
   rebaseWhen: "conflicted",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,42 @@
+{
+  // General
+  enabled: true,
+  dependencyDashboard: true,
+  dependencyDashboardTitle: "🤖 Renovate Dashboard",
+
+  // People
+  assigneesFromCodeOwners: true,
+  reviewersFromCodeOwners: true,
+  gitAuthor: "bugclerk <bugclerk@ixsystems.com>",
+
+  // Functionality
+  rebaseWhen: "conflicted",
+  packageRules: [
+    {
+      enabled: true,
+      matchManagers: ["dockerfile"],
+      updateTypes: ["patch", "minor", "major"],
+    },
+    // Labels
+    {
+      matchBaseBranches: ["master"],
+      addLabels: ["master"],
+    },
+    {
+      matchDepTypes: ["action"],
+      addLabels: ["actions"],
+    },
+    {
+      matchUpdateTypes: ["major"],
+      addLabels: ["major"],
+    },
+    {
+      matchUpdateTypes: ["minor"],
+      addLabels: ["minor"],
+    },
+    {
+      matchUpdateTypes: ["patch"],
+      addLabels: ["patch"],
+    },
+  ],
+}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -71,7 +71,16 @@ jobs:
         shell: bash
         run: |
           # Grab the version from the VERSION file
-          VERSION=$(cat ./apps/${{ matrix.containers.app }}/VERSION )
+          if [ -f ./apps/${{ matrix.containers.app }}/get_version.sh ]; then
+            if [ ! -x ./apps/${{ matrix.containers.app }}/get_version.sh ]; then
+              echo "get_version.sh is not executable, please check the permissions."
+              exit 1
+            fi
+            VERSION=$(./apps/${{ matrix.containers.app }}/get_version.sh ./apps/${{ matrix.containers.app }})
+          else
+            VERSION=$(cat ./apps/${{ matrix.containers.app }}/VERSION)
+          fi
+          echo "Version: $VERSION"
 
           result=$(docker manifest inspect "${{ env.REPOSITORY }}/${{ matrix.containers.app }}:$VERSION" || echo 1)
 
@@ -91,6 +100,8 @@ jobs:
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             OUTPUT_VERSION="unstable"
           fi
+
+          echo "Final version: $OUTPUT_VERSION"
 
           # Set the output
           echo "APP_VERSION=$OUTPUT_VERSION" >> $GITHUB_OUTPUT

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,6 +27,7 @@ jobs:
           - app: tftpd-hpa
           - app: rsyncd
           - app: postgres-upgrade
+          - app: nextcloud-fpm
 
     steps:
       - name: Checkout

--- a/apps/nextcloud-fpm/Dockerfile
+++ b/apps/nextcloud-fpm/Dockerfile
@@ -15,5 +15,14 @@ RUN set -ex; \
   touch /usr/local/etc/php/conf.d/redis-session.ini; \
   chmod 777 /usr/local/etc/php/conf.d/redis-session.ini
 
-COPY --chmod=755 ./scripts/occ /usr/bin/occ
+# Copy the healthcheck
 COPY --chmod=755 ./scripts/healthcheck.sh /healthcheck.sh
+
+# Copy the occ shortcut
+COPY --chmod=755 ./scripts/occ /usr/bin/occ
+
+# Copy the configure-scripts that will be sourced by the post-install
+COPY --chmod=755 ./configure-scripts /configure-scripts
+
+# Copy post-install script to the `before-starting` hooks dir so nextcloud will run those automatically.
+COPY --chmod=755 ./scripts/post-install.sh /docker-entrypoint-hooks.d/before-starting/10-post-install.sh

--- a/apps/nextcloud-fpm/Dockerfile
+++ b/apps/nextcloud-fpm/Dockerfile
@@ -3,11 +3,91 @@ FROM nextcloud:30.0.6-fpm
 RUN set -ex; \
   \
   apt-get update; \
+  # Install necessary runtime packages without recommended packages
   apt-get install -y --no-install-recommends \
+  # Tool for parsing and manipulating JSON
   jq \
+  # Simple text editor for the terminal
   nano \
+  # Utilities for monitoring processes
+  procps \
+  # Multimedia framework for handling audio/video
+  ffmpeg \
+  # Library for HEIF image format support
+  libheif1 \
+  # Tool for adding OCR text layer to scanned PDF files, making them searchable
+  ocrmypdf \
+  # Client for accessing Windows/Samba file shares
+  smbclient \
+  # Library for H.265/HEVC video format
+  libde265-0 \
+  # Office suite (document, spreadsheet, presentation apps)
+  libreoffice \
+  # FastCGI utilities for web servers
   libfcgi-bin \
-  ;
+  # Plugin to display HEIF images in GTK applications
+  heif-gdk-pixbuf \
+  # Common files for ImageMagick (image manipulation tool)
+  imagemagick-common \
+  ; \
+  \
+  # Save a list of currently manually installed packages
+  # This will be used later to restore the package state after building
+  savedAptMark="$(apt-mark showmanual)"; \
+  \
+  # Install build dependencies needed for compiling PHP extensions
+  apt-get update; \
+  apt-get install -y --no-install-recommends \
+  # Development files for bzip2 compression
+  libbz2-dev \
+  # Development files for Kerberos authentication
+  libkrb5-dev \
+  # Development files for c-client mail API (used by IMAP)
+  libc-client-dev \
+  # Development files for the SMB client library
+  libsmbclient-dev \
+  # Development files for ImageMagick core functionality
+  libmagickcore-dev \
+  ; \
+  \
+  # Configure the PHP IMAP extension with additional features
+  # --with-kerberos: Add Kerberos authentication support
+  # --with-imap-ssl: Add SSL encryption support
+  docker-php-ext-configure imap --with-kerberos --with-imap-ssl; \
+  # Install PHP extensions using the Docker PHP extension installer
+  docker-php-ext-install \
+  # Adds support for bzip2 compression in PHP
+  bz2 \
+  # Adds support for IMAP mail protocol in PHP
+  imap \
+  ; \
+  # Install the smbclient extension from PECL (PHP Extension Community Library)
+  # This allows PHP to interact with Windows/Samba file shares
+  pecl install smbclient; \
+  # Enable the smbclient extension in PHP
+  docker-php-ext-enable smbclient; \
+  \
+  # Mark all packages as automatically installed
+  # This prepares for clean-up of packages that were only needed for building
+  apt-mark auto '.*' > /dev/null; \
+  # Restore the packages that were manually installed before we started
+  apt-mark manual $savedAptMark; \
+  \
+  # Find and mark as manually installed any shared libraries that
+  # our PHP extensions depend on, so they don't get removed in the cleanup
+  ldd "$(php -r 'echo ini_get("extension_dir");')"/*.so \
+  | awk '/=>/ { so = $(NF-1); if (index(so, "/usr/local/") == 1) { next }; gsub("^/(usr/)?", "", so); print so }' \
+  | sort -u \
+  | xargs -r dpkg-query --search \
+  | cut -d: -f1 \
+  | sort -u \
+  | xargs -rt apt-mark manual; \
+  \
+  # Remove packages that were only needed for building extensions
+  # -o APT::AutoRemove::RecommendsImportant=false: Also remove recommended packages that are no longer needed
+  apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+  # Clean up the package cache to reduce the size of the Docker image
+  rm -rf /var/lib/apt/lists/*
 
 # See https://github.com/nextcloud/docker/issues/763
 RUN set -ex; \
@@ -17,12 +97,9 @@ RUN set -ex; \
 
 # Copy the healthcheck
 COPY --chmod=755 ./scripts/healthcheck.sh /healthcheck.sh
-
 # Copy the occ shortcut
 COPY --chmod=755 ./scripts/occ /usr/bin/occ
-
 # Copy the configure-scripts that will be sourced by the post-install
 COPY --chmod=755 ./configure-scripts /configure-scripts
-
 # Copy post-install script to the `before-starting` hooks dir so nextcloud will run those automatically.
 COPY --chmod=755 ./scripts/post-install.sh /docker-entrypoint-hooks.d/before-starting/10-post-install.sh

--- a/apps/nextcloud-fpm/Dockerfile
+++ b/apps/nextcloud-fpm/Dockerfile
@@ -1,0 +1,19 @@
+FROM nextcloud:30.0.6-fpm
+
+RUN set -ex; \
+  \
+  apt-get update; \
+  apt-get install -y --no-install-recommends \
+  jq \
+  nano \
+  libfcgi-bin \
+  ;
+
+# See https://github.com/nextcloud/docker/issues/763
+RUN set -ex; \
+  \
+  touch /usr/local/etc/php/conf.d/redis-session.ini; \
+  chmod 777 /usr/local/etc/php/conf.d/redis-session.ini
+
+COPY --chmod=755 ./scripts/occ /usr/bin/occ
+COPY --chmod=755 ./scripts/healthcheck.sh /healthcheck.sh

--- a/apps/nextcloud-fpm/README.md
+++ b/apps/nextcloud-fpm/README.md
@@ -41,11 +41,11 @@
 
 ### Expiration/Retention
 
-| Variable                  | Description                      |  App(s)  |          Config Key(s)          | Default | Example |
-| ------------------------- | -------------------------------- | :------: | :-----------------------------: | :-----: | :-----: |
-| `IX_ACTIVITY_EXPIRE_DAYS` | Expire days for activity app     | `system` |     `activity_expire_days`      |  `90`   |  `60`   |
-| `IX_TRASH_RETENTION`      | Retention time for deleted files | `system` | `trashbin_retention_obligation` | `auto`  | `30,60` |
-| `IX_VERSION_RETENTION`    | Retention time for old versions  | `system` | `versions_retention_obligation` | `auto`  | `30,60` |
+| Variable                  | Description                      |   App(s)   |          Config Key(s)          | Default | Example |
+| ------------------------- | -------------------------------- | :--------: | :-----------------------------: | :-----: | :-----: |
+| `IX_ACTIVITY_EXPIRE_DAYS` | Expire days for activity app     | `activity` |     `activity_expire_days`      |  `365`  |  `90`   |
+| `IX_TRASH_RETENTION`      | Retention time for deleted files |  `system`  | `trashbin_retention_obligation` | `auto`  | `30,60` |
+| `IX_VERSION_RETENTION`    | Retention time for old versions  |  `system`  | `versions_retention_obligation` | `auto`  | `30,60` |
 
 ### Redis
 

--- a/apps/nextcloud-fpm/README.md
+++ b/apps/nextcloud-fpm/README.md
@@ -1,0 +1,158 @@
+# Nextcloud Configuration
+
+## Environment Variables
+
+### General
+
+| Variable                      | Description                            |  App(s)  |     Config Key(s)      |  Default   |   Example   |
+| ----------------------------- | -------------------------------------- | :------: | :--------------------: | :--------: | :---------: |
+| `IX_RUN_OPTIMIZE`             | Runs optimize/repair/migration scripts |          |                        |   `true`   |   `false`   |
+| `IX_MAINTENANCE_WINDOW_START` | Sets the maintenance window start      |          |                        |   `100`    |     `1`     |
+| `IX_DEFAULT_PHONE_REGION`     | Default phone region                   | `system` | `default_phone_region` |    `GR`    |    `US`     |
+| `IX_SHARED_FOLDER_NAME`       | Name of shared folder                  | `system` |  `share_folder_name`   |    `/`     |  `Shared`   |
+| `IX_MAX_CHUNK_SIZE`           | Maximum chunk size                     | `files`  |    `max_chunk_size`    | `10485760` | `104857600` |
+
+### Logging
+
+| Variable             | Description     |  App(s)  |  Config Key(s)  |              Default               |        Example        |
+| -------------------- | --------------- | :------: | :-------------: | :--------------------------------: | :-------------------: |
+| `IX_LOG_LEVEL`       | Log level       | `system` |   `loglevel`    |                `2`                 |          `0`          |
+| `IX_LOG_FILE`        | Log file        | `system` |    `logfile`    | `/var/www/html/data/nextcloud.log` | `/logs/nextcloud.log` |
+| `IX_LOG_FILE_AUDIT`  | Audit log file  | `system` | `logfile_file`  |   `/var/www/html/data/audit.log`   |   `/logs/audit.log`   |
+| `IX_LOG_DATE_FORMAT` | Log date format | `system` | `logdateformat` |           `d/m/Y H:i:s`            |    `D d/m/Y H:i:s`    |
+| `IX_LOG_TIMEZONE`    | Log timezone    | `system` |  `logtimezone`  |               `$TZ`                |    `Europe/Athens`    |
+
+### URLs
+
+| Variable                | Description                             |  App(s)  |    Config Key(s)    | Default |                  Example                   |
+| ----------------------- | --------------------------------------- | :------: | :-----------------: | :-----: | :----------------------------------------: |
+| `IX_TRUSTED_DOMAINS`    | Space Separated list of Trusted domains | `system` |  `trusted_domains`  |  `""`   |       `localhost cloud.example.com`        |
+| `IX_TRUSTED_PROXIES`    | Space Separated list of Trusted proxies | `system` |  `trusted_proxies`  |  `""`   | `10.0.0.0/8 172.16.0.0./12 192.168.0.0/16` |
+| `IX_OVERWRITE_HOST`     | Overwrite host                          | `system` |   `overwritehost`   |  `""`   |            `cloud.example.com`             |
+| `IX_OVERWRITE_CLI_URL`  | Overwrite CLI URL                       | `system` | `overwrite.cli.url` |  `""`   |        `https://cloud.example.com`         |
+| `IX_OVERWRITE_PROTOCOL` | Overwrite protocol                      | `system` | `overwriteprotocol` |  `""`   |                  `https`                   |
+
+### Notify Push
+
+| Variable                  | Description                         |    App(s)     |      Config Key(s)       | Default |             Example              |
+| ------------------------- | ----------------------------------- | :-----------: | :----------------------: | :-----: | :------------------------------: |
+| `IX_NOTIFY_PUSH`          | Enable Nextcloud Push Notifications | `notify_push` | See `IX_NOTIFY_PUSH_URL` | `true`  |             `false`              |
+| `IX_NOTIFY_PUSH_ENDPOINT` | Nextcloud Push Notifications URL    | `notify_push` |     `base_endpoint`      |  `""`   | `https://cloud.example.com/push` |
+
+### Expiration/Retention
+
+| Variable                  | Description                      |  App(s)  |          Config Key(s)          | Default | Example |
+| ------------------------- | -------------------------------- | :------: | :-----------------------------: | :-----: | :-----: |
+| `IX_ACTIVITY_EXPIRE_DAYS` | Expire days for activity app     | `system` |     `activity_expire_days`      |  `90`   |  `60`   |
+| `IX_TRASH_RETENTION`      | Retention time for deleted files | `system` | `trashbin_retention_obligation` | `auto`  | `30,60` |
+| `IX_VERSION_RETENTION`    | Retention time for old versions  | `system` | `versions_retention_obligation` | `auto`  | `30,60` |
+
+### Redis
+
+| Variable        | Description    |  App(s)  |  Config Key(s)   | Default |    Example    |
+| --------------- | -------------- | :------: | :--------------: | :-----: | :-----------: |
+| `IX_REDIS`      | Enable Redis   |          |                  | `true`  |    `false`    |
+| `IX_REDIS_HOST` | Redis Host     | `system` |   `redis:host`   |  `""`   | `redis.local` |
+| `IX_REDIS_PASS` | Redis Password | `system` | `redis:password` |  `""`   |  `my-secret`  |
+| `IX_REDIS_PORT` | Redis Port     | `system` |   `redis:port`   | `6379`  |    `1234`     |
+
+### Database
+
+| Variable               | Description                |  App(s)  | Config Key(s) | Default |     Example     |
+| ---------------------- | -------------------------- | :------: | :-----------: | :-----: | :-------------: |
+| `IX_POSTGRES_HOST`     | Postgres Database Host     | `system` |   `dbhost`    |  `""`   | `192.168.1.100` |
+| `IX_POSTGRES_NAME`     | Postgres Database Name     | `system` |   `dbname`    |  `""`   |   `nextcloud`   |
+| `IX_POSTGRES_USER`     | Postgres Database User     | `system` |   `dbuser`    |  `""`   |   `nextcloud`   |
+| `IX_POSTGRES_PASSWORD` | Postgres Database Password | `system` | `dbpassword`  |  `""`   |   `my-secret`   |
+| `IX_POSTGRES_PORT`     | Postgres Database Port     | `system` |   `dbport`    | `5432`  |     `5555`      |
+
+### Previews
+
+| Variable                        | Description                                                                             |            App(s)             |                                           Config Key(s)                                            |  Default  |    Example     |
+| ------------------------------- | --------------------------------------------------------------------------------------- | :---------------------------: | :------------------------------------------------------------------------------------------------: | :-------: | :------------: |
+| `IX_PREVIEWS`                   | Enable Previews (Forced enabled if Imaginary is enabled)                                | `system` / `previewgenerator` | `system:enable_previews`, `system:enablePreviewProviders` and see `IX_PREVIEW_`, `IX_JPEG_QUALITY` |  `true`   |    `false`     |
+| `IX_IMAGINARY`                  | Enable Imaginary                                                                        |           `system`            |                                      `preview_imaginary_url`                                       |  `true`   |    `false`     |
+| `IX_PREVIEW_PROVIDERS`          | Space Separated list of Preview providers (Imaginary is added automatically if enabled) |           `system`            |                                     `enabledPreviewProviders`                                      |   `""`    | `JPEG PNG BPM` |
+| `IX_PREVIEW_MAX_X`              | Maximum width of preview image                                                          |           `system`            |                                          `preview_max_x`                                           |  `2048`   |     `1024`     |
+| `IX_PREVIEW_MAX_Y`              | Maximum height of preview image                                                         |           `system`            |                                          `preview_max_y`                                           |  `2048`   |     `1024`     |
+| `IX_PREVIEW_MAX_MEMORY`         | Maximum memory for preview image                                                        |           `system`            |                                        `preview_max_memory`                                        |  `1024`   |     `512`      |
+| `IX_PREVIEW_MAX_FILESIZE_IMAGE` | Maximum file size for image previews                                                    |           `system`            |                                    `preview_max_filesize_image`                                    |   `50`    |      `25`      |
+| `IX_JPEG_QUALITY`               | JPEG Quality for previews                                                               | `system` / `previewgenerator` |                           `system:jpeg_quality` / `preview:jpeg_quality`                           |   `60`    |      `80`      |
+| `IX_PREVIEW_HEIGHT_SIZES`       | Preview height sizes                                                                    |      `previewgenerator`       |                                           `heightSizes`                                            |   `256`   |     `512`      |
+| `IX_PREVIEW_WIDTH_SIZES`        | Preview width sizes                                                                     |      `previewgenerator`       |                                            `widthSizes`                                            | `256 384` |   `512 1024`   |
+| `IX_PREVIEW_SQUARE_SIZES`       | Preview square sizes                                                                    |      `previewgenerator`       |                                           `squareSizes`                                            | `32 256`  |    `64 512`    |
+
+### ClamAV
+
+| Variable                      | Description              |      App(s)       |     Config Key(s)      |  Default   |    Example     |
+| ----------------------------- | ------------------------ | :---------------: | :--------------------: | :--------: | :------------: |
+| `IX_CLAMAV`                   | Enable ClamAV            |                   |                        |  `false`   |     `true`     |
+| `IX_CLAMAV_HOST`              | ClamAV Host              | `files_antivirus` |       `av_host`        |    `""`    | `clamav.local` |
+| `IX_CLAMAV_PORT`              | ClamAV Port              | `files_antivirus` |       `av_port`        |    `""`    |     `3310`     |
+| `IX_CLAMAV_STREAM_MAX_LENGTH` | ClamAV Stream Max Length | `files_antivirus` | `av_stream_max_length` | `26214400` |   `1048576`    |
+| `IX_CLAMAV_MAX_FILE_SIZE`     | ClamAV Max File Size     | `files_antivirus` |   `av_max_file_size`   |    `-1`    |   `1048576`    |
+| `IX_CLAMAV_INFECTED_ACTION`   | ClamAV Infected Action   | `files_antivirus` |  `av_infected_action`  | `only_log` |    `delete`    |
+
+### Collabora
+
+| Variable                 | Description                                 |     App(s)      |         Config Key(s)          | Default |             Example             |
+| ------------------------ | ------------------------------------------- | :-------------: | :----------------------------: | :-----: | :-----------------------------: |
+| `IX_COLLABORA`           | Enable Collabora                            |                 |                                | `false` |             `true`              |
+| `IX_COLLABORA_URL`       | Collabora URL                               | `richdocuments` | `wopi_url` \ `public_wopi_url` |  `""`   | `https://collabora.example.com` |
+| `IX_COLLABORA_ALLOWLIST` | Collabora WOPI Allow List (Comma Separated) | `richdocuments` |        `wopi_allowlist`        |  `""`   |   `172.16.0.0/12,10.0.0.0/12`   |
+
+### Onlyoffice
+
+| Variable                   | Description           |    App(s)    |    Config Key(s)    | Default |             Example              |
+| -------------------------- | --------------------- | :----------: | :-----------------: | :-----: | :------------------------------: |
+| `IX_ONLYOFFICE`            | Enable OnlyOffice     |              |                     | `false` |              `true`              |
+| `IX_ONLYOFFICE_URL`        | OnlyOffice URL        | `onlyoffice` | `DocumentServerUrl` |  `""`   | `https://onlyoffice.example.com` |
+| `IX_ONLYOFFICE_JWT`        | OnlyOffice JWT        | `onlyoffice` |    `jwt_secret`     |  `""`   |  `random_string_of_characters`   |
+| `IX_ONLYOFFICE_JWT_HEADER` | OnlyOffice JWT Header | `onlyoffice` |    `jwt_header`     |  `""`   |         `Authorization`          |
+
+> Visit Nextcloud official documentation for more information about each `Config key`
+>
+> Also see [config example](https://github.com/nextcloud/server/blob/master/config/config.sample.php)
+
+## Recommended additions for nextcloud optimizations
+
+> Partial docker-compose file
+
+```yaml
+services:
+  nextcloud:
+    configs:
+      - source: php-tune
+        target: /usr/local/etc/php-fpm.d/zz-tune.conf
+      - source: redis-session
+        target: /usr/local/etc/php/conf.d/redis-session.ini
+      - source: opcache-recommended
+        target: /usr/local/etc/php/conf.d/opcache-recommended.ini
+
+configs:
+  php-tune:
+    content: |
+      [www]
+      pm.max_children = 180
+      pm.start_servers = 18
+      pm.min_spare_servers = 12
+      pm.max_spare_servers = 30
+  redis-session:
+    content: |
+      session.save_handler = redis
+      session.save_path = "tcp://redis:6379?auth=REPLACE_ME"
+      redis.session.locking_enabled = 1
+      redis.session.lock_retries = -1
+      redis.session.lock_wait_time = 10000
+  opcache-recommended:
+    content: |
+      opcache.enable=1
+      opcache.enable_cli=1
+      opcache.save_comments=1
+      opcache.jit=1255
+      opcache.interned_strings_buffer=32
+      opcache.max_accelerated_files=10000
+      opcache.memory_consumption=128
+      opcache.revalidate_freq=60
+      opcache.jit_buffer_size=128M
+```

--- a/apps/nextcloud-fpm/configure-scripts/helpers.sh
+++ b/apps/nextcloud-fpm/configure-scripts/helpers.sh
@@ -77,3 +77,15 @@ set_list() {
     done
   fi
 }
+
+extract_domain() {
+  url="$1"
+
+  # Remove http(s):// from URL
+  domain="${url#*://}"
+
+  # Remove /foo (subfolder) from domain
+  domain="${domain%%/*}"
+
+  echo "$domain"
+}

--- a/apps/nextcloud-fpm/configure-scripts/helpers.sh
+++ b/apps/nextcloud-fpm/configure-scripts/helpers.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+
+# Installs the passed application if not already installed
+install_app() {
+  app_name="${1:?"app_name is unset"}"
+
+  echo "Installing [$app_name]..."
+
+  if occ app:list | grep -wq "$app_name"; then
+    echo "App [$app_name] is already installed! Skipping..."
+    return 0
+  fi
+
+  if ! occ app:install "$app_name"; then
+    echo "Failed to install $app_name..."
+    exit 1
+  fi
+
+  echo "App [$app_name] installed successfully!"
+}
+
+remove_app() {
+  app_name="${1:?"app_name is unset"}"
+
+  echo "Removing [$app_name]..."
+
+  if ! occ app:list | grep -wq "$app_name"; then
+    echo "App [$app_name] is not installed! Skipping..."
+    return 0
+  fi
+
+  if ! occ app:remove "$app_name"; then
+    echo "Failed to remove [$app_name]..."
+    exit 1
+  fi
+
+  echo "App [$app_name] removed successfully!"
+}
+
+# Sets a space separated values into the specified list, by default for system settings
+# Pass a 3rd argument for a different app
+set_list() {
+  list_name="${1:?"list_name is unset"}"
+  space_delimited_values="${2:?"space_delimited_values is unset"}"
+  app="${3:-"system"}"
+  prefix="${4:-""}"
+
+  if [ -n "${space_delimited_values}" ]; then
+
+    if [ "${app}" != 'system' ]; then
+      occ config:app:delete "$app" "$list_name"
+    else
+      occ config:system:delete "$list_name"
+    fi
+
+    IDX=0
+    # Replace spaces with newlines so the input can have
+    # mixed entries of space or new line separated values
+    echo "$space_delimited_values" | tr ' ' '\n' | while IFS= read -r value; do
+      # Skip empty values
+      if [ -z "$value" ]; then
+        continue
+      fi
+
+      # Prepend prefix (eg OC\Preview)
+      if [ -n "${prefix}" ]; then
+        value="$prefix$value"
+      fi
+
+      if [ "${app}" != 'system' ]; then
+        occ config:app:set "$app" "$list_name" $IDX --value="$value"
+      else
+        occ config:system:set "$list_name" $IDX --value="$value"
+      fi
+
+      IDX=$((IDX + 1))
+    done
+  fi
+}

--- a/apps/nextcloud-fpm/configure-scripts/occ-clamav.sh
+++ b/apps/nextcloud-fpm/configure-scripts/occ-clamav.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+occ_clamav_install() {
+  echo '## Configuring ClamAV...'
+  install_app files_antivirus
+
+  occ config:app:set files_antivirus av_mode --value="daemon"
+  occ config:app:set files_antivirus av_host --value="${IX_CLAMAV_HOST:?"IX_CLAMAV_HOST is unset"}"
+  occ config:app:set files_antivirus av_port --value="${IX_CLAMAV_PORT:-3310}"
+  occ config:app:set files_antivirus av_stream_max_length --value="${IX_CLAMAV_STREAM_MAX_LENGTH:-26214400}"
+  occ config:app:set files_antivirus av_max_file_size --value="${IX_CLAMAV_MAX_FILE_SIZE:-"-1"}"
+  occ config:app:set files_antivirus av_infected_action --value="${IX_CLAMAV_INFECTED_ACTION:-"only_log"}"
+}
+
+occ_clamav_remove() {
+  echo '## Removing ClamAV Configuration...'
+  remove_app files_antivirus
+
+  occ config:app:delete files_antivirus av_mode
+  occ config:app:delete files_antivirus av_host
+  occ config:app:delete files_antivirus av_port
+  occ config:app:delete files_antivirus av_stream_max_length
+  occ config:app:delete files_antivirus av_max_file_size
+  occ config:app:delete files_antivirus av_infected_action
+}

--- a/apps/nextcloud-fpm/configure-scripts/occ-collabora.sh
+++ b/apps/nextcloud-fpm/configure-scripts/occ-collabora.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+occ_collabora_install() {
+  echo '## Configuring Collabora...'
+  install_app richdocuments
+
+  occ config:app:set richdocuments wopi_url --value="${IX_COLLABORA_URL:?"IX_COLLABORA_URL is unset"}"
+  occ config:app:set richdocuments public_wopi_url --value="${IX_COLLABORA_URL:?"IX_COLLABORA_URL is unset"}"
+  occ config:app:set richdocuments wopi_allowlist --value="${IX_COLLABORA_ALLOWLIST:?"IX_COLLABORA_ALLOWLIST is unset"}"
+}
+
+occ_collabora_remove() {
+  echo '## Removing Collabora Configuration...'
+  remove_app richdocuments
+
+  occ config:app:delete richdocuments wopi_url
+  occ config:app:delete richdocuments public_wopi_url
+  occ config:app:delete richdocuments wopi_allowlist
+}

--- a/apps/nextcloud-fpm/configure-scripts/occ-database.sh
+++ b/apps/nextcloud-fpm/configure-scripts/occ-database.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+occ_database() {
+  echo '## Configuring Database...'
+
+  occ config:system:set dbtype --value="pgsql"
+  occ config:system:set dbhost --value="${IX_POSTGRES_HOST:?"IX_POSTGRES_HOST is unset"}"
+  occ config:system:set dbname --value="${IX_POSTGRES_NAME:?"IX_POSTGRES_NAME is unset"}"
+  occ config:system:set dbuser --value="${IX_POSTGRES_USER:?"IX_POSTGRES_USER is unset"}"
+  occ config:system:set dbpassword --value="${IX_POSTGRES_PASSWORD:?"IX_POSTGRES_PASSWORD is unset"}"
+  occ config:system:set dbport --value="${IX_POSTGRES_PORT:-5432}"
+}

--- a/apps/nextcloud-fpm/configure-scripts/occ-database.sh
+++ b/apps/nextcloud-fpm/configure-scripts/occ-database.sh
@@ -1,11 +1,52 @@
 #!/bin/sh
+
+# Note that this assumes:
+# - Key is top-level key in config.php
+# - Value is always a string
+update_db_config() {
+  key="$1"
+  value="$2"
+  filepath="$3"
+
+  # We Base64 encode and decode the value to safely handle special characters
+  php <<EOF
+  <?php
+    \$key = '$key';
+    \$value = '$value';
+    \$filepath = '$filepath';
+
+    \$encoded_value = base64_decode('$(printf "%s" "$value" | base64)');
+
+    include(\$filepath);
+    \$CONFIG[\$key] = (string)\$encoded_value;
+    file_put_contents(\$filepath, "<?php\n\\\$CONFIG = ".var_export(\$CONFIG, true).";\n");
+EOF
+}
+
 occ_database() {
   echo '## Configuring Database...'
 
-  occ config:system:set dbtype --value="pgsql"
-  occ config:system:set dbhost --value="${IX_POSTGRES_HOST:?"IX_POSTGRES_HOST is unset"}"
-  occ config:system:set dbname --value="${IX_POSTGRES_NAME:?"IX_POSTGRES_NAME is unset"}"
-  occ config:system:set dbuser --value="${IX_POSTGRES_USER:?"IX_POSTGRES_USER is unset"}"
-  occ config:system:set dbpassword --value="${IX_POSTGRES_PASSWORD:?"IX_POSTGRES_PASSWORD is unset"}"
-  occ config:system:set dbport --value="${IX_POSTGRES_PORT:-5432}"
+  config_file="{$IX_CONFIG_FILE_PATH:-/var/www/html/config/config.php}"
+
+  if [ ! -f "$config_file" ]; then
+    echo "Config file $config_file does not exist. Something is wrong."
+    exit 1
+  fi
+
+  update_db_config 'dbtype' 'pgsql' "${config_file}"
+  update_db_config 'dbhost' "${IX_POSTGRES_HOST:?"IX_POSTGRES_HOST is unset"}" "${config_file}"
+  update_db_config 'dbname' "${IX_POSTGRES_NAME:?"IX_POSTGRES_NAME is unset"}" "${config_file}"
+  update_db_config 'dbuser' "${IX_POSTGRES_USER:?"IX_POSTGRES_USER is unset"}" "${config_file}"
+  update_db_config 'dbpassword' "${IX_POSTGRES_PASSWORD:?"IX_POSTGRES_PASSWORD is unset"}" "${config_file}"
+  update_db_config 'dbport' "${IX_POSTGRES_PORT:-5432}" "${config_file}"
+
+  # - https://github.com/nextcloud/server/issues/44924
+  # Due to a bug in Nextcloud, you cannot use `occ` to update the db config if you are not connected to the database.
+
+  # occ config:system:set dbtype --value="pgsql"
+  # occ config:system:set dbhost --value="${IX_POSTGRES_HOST:?"IX_POSTGRES_HOST is unset"}"
+  # occ config:system:set dbname --value="${IX_POSTGRES_NAME:?"IX_POSTGRES_NAME is unset"}"
+  # occ config:system:set dbuser --value="${IX_POSTGRES_USER:?"IX_POSTGRES_USER is unset"}"
+  # occ config:system:set dbpassword --value="${IX_POSTGRES_PASSWORD:?"IX_POSTGRES_PASSWORD is unset"}"
+  # occ config:system:set dbport --value="${IX_POSTGRES_PORT:-5432}"
 }

--- a/apps/nextcloud-fpm/configure-scripts/occ-expire-retentions.sh
+++ b/apps/nextcloud-fpm/configure-scripts/occ-expire-retentions.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+occ_expire_retention() {
+  echo '## Configuring Expiring and Retention Days...'
+  occ config:system:set activity_expire_days --value="${IX_ACTIVITY_EXPIRE_DAYS:-90}" --type=integer
+  occ config:system:set trashbin_retention_obligation --value="${IX_TRASH_RETENTION:-auto}"
+  occ config:system:set versions_retention_obligation --value="${IX_VERSIONS_RETENTION:-auto}"
+}

--- a/apps/nextcloud-fpm/configure-scripts/occ-expire-retentions.sh
+++ b/apps/nextcloud-fpm/configure-scripts/occ-expire-retentions.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 occ_expire_retention() {
   echo '## Configuring Expiring and Retention Days...'
-  occ config:system:set activity_expire_days --value="${IX_ACTIVITY_EXPIRE_DAYS:-90}" --type=integer
+  occ config:system:set activity_expire_days --value="${IX_ACTIVITY_EXPIRE_DAYS:-365}" --type=integer
   occ config:system:set trashbin_retention_obligation --value="${IX_TRASH_RETENTION:-auto}"
   occ config:system:set versions_retention_obligation --value="${IX_VERSIONS_RETENTION:-auto}"
 }

--- a/apps/nextcloud-fpm/configure-scripts/occ-general.sh
+++ b/apps/nextcloud-fpm/configure-scripts/occ-general.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+occ_general() {
+  echo '## Disabling WebUI Updater...'
+  occ config:system:set upgrade.disable-web --type=bool --value=true
+
+  echo '## Configuring Default Phone Region...'
+  occ config:system:set default_phone_region --value=${IX_DEFAULT_PHONE_REGION:-GR}
+
+  echo '## Configuring "Shared" folder...'
+  occ config:system:set share_folder --value="${IX_SHARED_FOLDER_NAME:-/}"
+
+  echo '## Configuring Max Chunk Size for Files...'
+  occ config:app:set files max_chunk_size --value="${IX_MAX_CHUNKSIZE:-10485760}"
+
+  echo '## Configuring Maintenance Window Start...'
+  occ config:system:set maintenance_window_start --type=integer --value="${IX_MAINTENANCE_WINDOW_START:-100}"
+}

--- a/apps/nextcloud-fpm/configure-scripts/occ-imaginary.sh
+++ b/apps/nextcloud-fpm/configure-scripts/occ-imaginary.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+occ_imaginary_install() {
+  echo '## Configuring Imaginary...'
+  occ config:system:set preview_imaginary_url --value="${IX_IMAGINARY_URL:?"NX_IMAGINARY_URL is unset"}"
+}
+
+occ_imaginary_remove() {
+  echo '## Removing Imaginary Configuration...'
+  occ config:system:delete preview_imaginary_url
+}

--- a/apps/nextcloud-fpm/configure-scripts/occ-imaginary.sh
+++ b/apps/nextcloud-fpm/configure-scripts/occ-imaginary.sh
@@ -2,7 +2,7 @@
 
 occ_imaginary_install() {
   echo '## Configuring Imaginary...'
-  occ config:system:set preview_imaginary_url --value="${IX_IMAGINARY_URL:?"NX_IMAGINARY_URL is unset"}"
+  occ config:system:set preview_imaginary_url --value="${IX_IMAGINARY_URL:?"IX_IMAGINARY_URL is unset"}"
 }
 
 occ_imaginary_remove() {

--- a/apps/nextcloud-fpm/configure-scripts/occ-logging.sh
+++ b/apps/nextcloud-fpm/configure-scripts/occ-logging.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+occ_logging() {
+  echo '## Configuring Logging...'
+  occ config:system:set log_type --value="file"
+  occ config:system:set log_type_audit --value="file"
+  occ config:system:set loglevel --value="${IX_LOG_LEVEL:-2}"
+  occ config:system:set logfile --value="${IX_LOG_FILE:-"/var/www/html/data/nextcloud.log"}"
+  occ config:system:set logfile_audit --value="${IX_LOG_FILE_AUDIT:-"/var/www/html/data/audit.log"}"
+  occ config:system:set logdateformat --value="${IX_LOG_DATE_FORMAT:-"d/m/Y H:i:s"}"
+  occ config:system:set logtimezone --value="${IX_LOG_TIMEZONE:-$TZ}"
+}

--- a/apps/nextcloud-fpm/configure-scripts/occ-notify-push.sh
+++ b/apps/nextcloud-fpm/configure-scripts/occ-notify-push.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+occ_notify_push_install() {
+  echo '## Configuring Notify Push...'
+  install_app notify_push
+
+  echo '## Configuring Notify Push Base Endpoint...'
+  occ config:app:set notify_push base_endpoint --value="${IX_NOTIFY_PUSH_ENDPOINT:?"IX_NOTIFY_PUSH_ENDPOINT is unset"}"
+}
+
+occ_notify_push_remove() {
+  echo '## Removing Notify Push...'
+  remove_app notify_push
+
+  echo '## Removing Notify Push Base Endpoint...'
+  occ config:app:delete notify_push base_endpoint
+}

--- a/apps/nextcloud-fpm/configure-scripts/occ-onlyoffice.sh
+++ b/apps/nextcloud-fpm/configure-scripts/occ-onlyoffice.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+occ_onlyoffice_install() {
+  echo '## Configuring OnlyOffice...'
+  install_app onlyoffice
+
+  occ config:app:set onlyoffice DocumentServerUrl --value="${IX_ONLYOFFICE_URL:?"IX_ONLYOFFICE_URL is unset"}"
+  occ config:system:set onlyoffice jwt_secret --value="${IX_ONLYOFFICE_JWT:?"IX_ONLYOFFICE_JWT is unset"}"
+  occ config:system:set onlyoffice jwt_header --value="${IX_ONLYOFFICE_JWT_HEADER:-"Authorization"}"
+}
+
+occ_onlyoffice_remove() {
+  echo '## Removing OnlyOffice Configuration...'
+  remove_app onlyoffice
+
+  occ config:app:delete onlyoffice DocumentServerUrl
+  occ config:system:delete onlyoffice jwt_secret
+  occ config:system:delete onlyoffice jwt_header
+}

--- a/apps/nextcloud-fpm/configure-scripts/occ-optimize.sh
+++ b/apps/nextcloud-fpm/configure-scripts/occ-optimize.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+occ_optimize() {
+  echo '## Applying migrations/repairs/optimizations...'
+  occ db:add-missing-indices
+  occ db:add-missing-columns
+  occ db:add-missing-primary-keys
+  yes | occ db:convert-filecache-bigint
+  occ maintenance:mimetype:update-js
+  occ maintenance:mimetype:update-db
+  occ maintenance:update:htaccess
+  occ maintenance:repair --include-expensive
+}

--- a/apps/nextcloud-fpm/configure-scripts/occ-preview-generator.sh
+++ b/apps/nextcloud-fpm/configure-scripts/occ-preview-generator.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+occ_preview_generator_install() {
+  echo '## Configuring Preview Generator...'
+  install_app previewgenerator
+
+  echo '## Configuring Preview Providers...'
+  [ "${IX_PREVIEW_PROVIDERS:?"IX_PREVIEW_PROVIDERS is unset"}" ]
+
+  # Adds Imaginary if enabled
+  if [ "${IX_IMAGINARY:-"true"}" = "true" ]; then
+    IX_PREVIEW_PROVIDERS="Imaginary ${IX_PREVIEW_PROVIDERS}"
+  fi
+
+  set_list 'enabledPreviewProviders' "${IX_PREVIEW_PROVIDERS}" 'system' 'OC\Preview\'
+
+  echo '## Configuring Preview Generation Configuration...'
+  occ config:system:set enable_previews --value=true
+  occ config:system:set jpeg_quality --value="${IX_JPEG_QUALITY:-60}" --type=integer
+  occ config:system:set preview_max_x --value="${IX_PREVIEW_MAX_X:-2048}" --type=integer
+  occ config:system:set preview_max_y --value="${IX_PREVIEW_MAX_Y:-2048}" --type=integer
+  occ config:system:set preview_max_memory --value="${IX_PREVIEW_MAX_MEMORY:-1024}" --type=integer
+  occ config:system:set preview_max_filesize_image --value="${IX_PREVIEW_MAX_FILESIZE_IMAGE:-50}" --type=integer
+  occ config:app:set previewgenerator squareSizes --value="${IX_PREVIEW_SQUARE_SIZES:-32 256}"
+  occ config:app:set previewgenerator widthSizes --value="${IX_PREVIEW_WIDTH_SIZES:-256 384}"
+  occ config:app:set previewgenerator heightSizes --value="${IX_PREVIEW_HEIGHT_SIZES:-256}"
+  occ config:app:set preview jpeg_quality --value="${IX_JPEG_QUALITY:-60}"
+}
+
+occ_preview_generator_remove() {
+  echo '## Removing Preview Generator...'
+  remove_app previewgenerator
+
+  echo '## Removing Preview Providers...'
+  occ config:system:delete enabledPreviewProviders
+
+  echo '## Removing Preview Generation Configuration...'
+  occ config:system:set enable_previews --value=false
+  occ config:system:delete jpeg_quality
+  occ config:system:delete preview_max_x
+  occ config:system:delete preview_max_y
+  occ config:system:delete preview_max_memory
+  occ config:system:delete preview_max_filesize_image
+  occ config:app:delete previewgenerator squareSizes
+  occ config:app:delete previewgenerator widthSizes
+  occ config:app:delete previewgenerator heightSizes
+  occ config:app:delete preview jpeg_quality
+}

--- a/apps/nextcloud-fpm/configure-scripts/occ-redis.sh
+++ b/apps/nextcloud-fpm/configure-scripts/occ-redis.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+occ_redis_install() {
+  echo '## Configuring Redis...'
+
+  occ config:system:set redis host --value="${IX_REDIS_HOST:?"IX_REDIS_HOST is unset"}"
+  occ config:system:set redis password --value="${IX_REDIS_PASS:?"IX_REDIS_PASS is unset"}"
+  occ config:system:set redis port --value="${IX_REDIS_PORT:-6379}"
+  occ config:system:set memcache.local --value="\\OC\\Memcache\\APCu"
+  occ config:system:set memcache.distributed --value="\\OC\\Memcache\\Redis"
+  occ config:system:set memcache.locking --value="\\OC\\Memcache\\Redis"
+}
+
+occ_redis_remove() {
+  echo '## Removing Redis Configuration...'
+
+  occ config:system:set memcache.local --value="\\OC\\Memcache\\APCu"
+  occ config:system:delete memcache.distributed
+  occ config:system:delete memcache.locking
+  occ config:system:delete redis
+}

--- a/apps/nextcloud-fpm/configure-scripts/occ-urls.sh
+++ b/apps/nextcloud-fpm/configure-scripts/occ-urls.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+occ_urls() {
+  echo '## Configuring Overwrite URLs...'
+  occ config:system:set overwrite.cli.url --value="${IX_OVERWRITE_CLI_URL:?"IX_OVERWRITE_CLI_URL is unset"}"
+  occ config:system:set overwritehost --value="${IX_OVERWRITE_HOST:?"IX_OVERWRITE_HOST is unset"}"
+  occ config:system:set overwriteprotocol --value="${IX_OVERWRITE_PROTOCOL:?"IX_OVERWRITE_PROTOCOL is unset"}"
+
+  echo '## Configuring Trusted Domains...'
+  [ "${IX_TRUSTED_DOMAINS:?"IX_TRUSTED_DOMAINS is unset"}" ]
+
+  # If Collabora is enabled, add Collabora URL to trusted domains
+  if [ "${IX_COLLABORA:-"false"}" = "true" ]; then
+    [ "${IX_COLLABORA_URL:?"IX_COLLABORA_URL is unset"}" ]
+    IX_COLLABORA_DOMAIN=$(extract_domain "$IX_COLLABORA_URL")
+    if [ "${IX_COLLABORA_DOMAIN}" != "${IX_OVERWRITE_HOST}" ]; then
+      IX_TRUSTED_DOMAINS="${IX_TRUSTED_DOMAINS} ${IX_COLLABORA_DOMAIN}"
+    fi
+  fi
+
+  # If OnlyOffice is enabled, add OnlyOffice URL to trusted domains
+  if [ "${IX_ONLYOFFICE:-"false"}" = "true" ]; then
+    [ "${IX_ONLYOFFICE_URL:?"IX_ONLYOFFICE_URL is unset"}" ]
+    IX_ONLYOFFICE_DOMAIN=$(extract_domain "$IX_ONLYOFFICE_URL")
+    if [ "${IX_ONLYOFFICE_DOMAIN}" != "${IX_OVERWRITE_HOST}" ]; then
+      IX_TRUSTED_DOMAINS="${IX_TRUSTED_DOMAINS} ${IX_ONLYOFFICE_DOMAIN}"
+    fi
+  fi
+
+  set_list 'trusted_domains' "${IX_TRUSTED_DOMAINS}" 'system'
+
+  echo '## Configuring Trusted Proxies...'
+  set_list 'trusted_proxies' "${IX_TRUSTED_PROXIES:?"IX_TRUSTED_PROXIES is unsed"}" 'system'
+}

--- a/apps/nextcloud-fpm/get_version.sh
+++ b/apps/nextcloud-fpm/get_version.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+curr_dir="$1"
+VERSION=$(cat $curr_dir/Dockerfile | grep "FROM nextcloud:" | cut -d ':' -f2 | cut -d '@' -f1)
+
+build_id=$(date +%Y%m%d%H%M%S)
+
+echo "$VERSION-$build_id"

--- a/apps/nextcloud-fpm/get_version.sh
+++ b/apps/nextcloud-fpm/get_version.sh
@@ -2,6 +2,8 @@
 curr_dir="$1"
 VERSION=$(cat $curr_dir/Dockerfile | grep "FROM nextcloud:" | cut -d ':' -f2 | cut -d '@' -f1)
 
-build_id=$(date +%Y%m%d%H%M%S)
-
+# Generate a build id based on the files in the current directory
+build_id=$(find "$curr_dir" -type f -exec sha256sum {} \; | sort | sha256sum | cut -d ' ' -f1)
+# Truncate the build id to 8 characters
+build_id=${build_id:0:8}
 echo "$VERSION-$build_id"

--- a/apps/nextcloud-fpm/scripts/healthcheck.sh
+++ b/apps/nextcloud-fpm/scripts/healthcheck.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+REQUEST_METHOD="GET" \
+SCRIPT_NAME="status.php" \
+SCRIPT_FILENAME="status.php" \
+cgi-fcgi -bind -connect "127.0.0.1:9000" | grep -q '"installed":true' || exit 1

--- a/apps/nextcloud-fpm/scripts/occ
+++ b/apps/nextcloud-fpm/scripts/occ
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+uid="$(id -u)"
+gid="$(id -g)"
+
+if [ "$uid" = '0' ]; then
+  user='www-data'
+  group='www-data'
+else
+  user="$uid"
+  group="$gid"
+fi
+
+run_as() {
+  if [ "$(id -u)" = 0 ]; then
+    su -p "$user" -s /bin/bash -c "php /var/www/html/occ $(printf '%q ' "$@")"
+  else
+    /bin/bash -c "php /var/www/html/occ $(printf '%q ' "$@")"
+  fi
+}
+
+run_as "$@"

--- a/apps/nextcloud-fpm/scripts/post-install.sh
+++ b/apps/nextcloud-fpm/scripts/post-install.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+echo '++++++++++++++++++++++++++++++++++++++++++++++++++'
+echo ''
+### Source all configure-scripts. ###
+for script in /configure-scripts/*.sh; do
+  echo "Sourcing $script"
+  . "$script"
+done
+
+echo ''
+echo 'Executing injected scripts...'
+echo '++++++++++++++++++++++++++++++++++++++++++++++++++'
+echo ''
+
+### Start Configuring ###
+
+echo ''
+# If Imaginary is enabled, previews are forced enabled
+if [ "${IX_IMAGINARY:-"true"}" = "true" ]; then
+  IX_PREVIEWS="true"
+  echo '# Imaginary is enabled.'
+  occ_imaginary_install
+else
+  echo '# Imaginary is disabled.'
+  occ_imaginary_remove
+fi
+
+echo ''
+# If Imaginary is disabled but previews are enabled, configure only previews
+if [ "${IX_PREVIEWS:-"true"}" = "true" ]; then
+  echo '# Preview Generator is enabled.'
+  occ_preview_generator_install
+else
+  echo '# Preview Generator is disabled.'
+  occ_preview_generator_remove
+fi
+
+echo ''
+if [ "${IX_CLAMAV:-"false"}" = "true" ]; then
+  echo '# ClamAV is enabled.'
+  occ_clamav_install
+else
+  echo '# ClamAV is disabled.'
+  occ_clamav_remove
+fi

--- a/apps/nextcloud-fpm/scripts/post-install.sh
+++ b/apps/nextcloud-fpm/scripts/post-install.sh
@@ -27,6 +27,10 @@ fi
 echo ''
 occ_database
 
+# Configure General Settings
+echo ''
+occ_general
+
 echo ''
 # If Imaginary is enabled, previews are forced enabled
 if [ "${IX_IMAGINARY:-"true"}" = "true" ]; then

--- a/apps/nextcloud-fpm/scripts/post-install.sh
+++ b/apps/nextcloud-fpm/scripts/post-install.sh
@@ -23,6 +23,10 @@ else
   occ_redis_remove
 fi
 
+# Configure Database
+echo ''
+occ_database
+
 echo ''
 # If Imaginary is enabled, previews are forced enabled
 if [ "${IX_IMAGINARY:-"true"}" = "true" ]; then

--- a/apps/nextcloud-fpm/scripts/post-install.sh
+++ b/apps/nextcloud-fpm/scripts/post-install.sh
@@ -31,6 +31,10 @@ occ_database
 echo ''
 occ_general
 
+# Configure Logging
+echo ''
+occ_logging
+
 echo ''
 # If Imaginary is enabled, previews are forced enabled
 if [ "${IX_IMAGINARY:-"true"}" = "true" ]; then

--- a/apps/nextcloud-fpm/scripts/post-install.sh
+++ b/apps/nextcloud-fpm/scripts/post-install.sh
@@ -53,3 +53,18 @@ else
   echo '# Collabora is disabled.'
   occ_collabora_remove
 fi
+
+echo ''
+if [ "${IX_ONLYOFFICE:-"false"}" = "true" ]; then
+  echo '# OnlyOffice is enabled.'
+  occ_onlyoffice_install
+else
+  echo '# OnlyOffice is disabled.'
+  occ_onlyoffice_remove
+fi
+
+if [ "${IX_ONLYOFFICE:-"false"}" = "true" ] || [ "${IX_COLLABORA:-"false"}" = "true" ]; then
+  occ config:system:set allow_local_remote_servers --value="true"
+else
+  occ config:system:delete allow_local_remote_servers
+fi

--- a/apps/nextcloud-fpm/scripts/post-install.sh
+++ b/apps/nextcloud-fpm/scripts/post-install.sh
@@ -35,6 +35,23 @@ occ_general
 echo ''
 occ_logging
 
+# Configure URLs (Trusted Domains, Trusted Proxies, Overwrites, etc)
+echo ''
+occ_urls
+
+# Configure Expiration/Retention Days
+echo ''
+occ_expire_retention
+
+echo ''
+if [ "${IX_NOTIFY_PUSH:-"true"}" = "true" ]; then
+  echo '# Notify Push is enabled.'
+  occ_notify_push_install
+else
+  echo '# Notify Push is disabled.'
+  occ_notify_push_remove
+fi
+
 echo ''
 # If Imaginary is enabled, previews are forced enabled
 if [ "${IX_IMAGINARY:-"true"}" = "true" ]; then

--- a/apps/nextcloud-fpm/scripts/post-install.sh
+++ b/apps/nextcloud-fpm/scripts/post-install.sh
@@ -44,3 +44,12 @@ else
   echo '# ClamAV is disabled.'
   occ_clamav_remove
 fi
+
+echo ''
+if [ "${IX_COLLABORA:-"false"}" = "true" ]; then
+  echo '# Collabora is enabled.'
+  occ_collabora_install
+else
+  echo '# Collabora is disabled.'
+  occ_collabora_remove
+fi

--- a/apps/nextcloud-fpm/scripts/post-install.sh
+++ b/apps/nextcloud-fpm/scripts/post-install.sh
@@ -14,15 +14,6 @@ echo '++++++++++++++++++++++++++++++++++++++++++++++++++'
 echo ''
 
 ### Start Configuring ###
-# Configure Redis
-if [ "${IX_REDIS:-"true"}" = "true" ]; then
-  echo '# Redis is enabled.'
-  occ_redis_install
-else
-  echo '# Redis is disabled.'
-  occ_redis_remove
-fi
-
 # Configure Database
 echo ''
 occ_database
@@ -42,6 +33,15 @@ occ_urls
 # Configure Expiration/Retention Days
 echo ''
 occ_expire_retention
+
+# Configure Redis
+if [ "${IX_REDIS:-"true"}" = "true" ]; then
+  echo '# Redis is enabled.'
+  occ_redis_install
+else
+  echo '# Redis is disabled.'
+  occ_redis_remove
+fi
 
 echo ''
 if [ "${IX_NOTIFY_PUSH:-"true"}" = "true" ]; then

--- a/apps/nextcloud-fpm/scripts/post-install.sh
+++ b/apps/nextcloud-fpm/scripts/post-install.sh
@@ -68,3 +68,23 @@ if [ "${IX_ONLYOFFICE:-"false"}" = "true" ] || [ "${IX_COLLABORA:-"false"}" = "t
 else
   occ config:system:delete allow_local_remote_servers
 fi
+
+echo ''
+echo '++++++++++++++++++++++++++++++++++++++++++++++++++'
+### End Configuring ###
+
+echo '--------------------------------------------------'
+echo ''
+
+# Run optimize/repairs/migrations
+if [ "${IX_RUN_OPTIMIZE:-"true"}" = "true" ]; then
+  echo '# Optimize is enabled. Running...'
+  occ_optimize
+else
+  echo '# Optimize is disabled. Skipping...'
+fi
+
+echo ''
+echo '--------------------------------------------------'
+
+echo 'Starting Nextcloud PHP-FPM'

--- a/apps/nextcloud-fpm/scripts/post-install.sh
+++ b/apps/nextcloud-fpm/scripts/post-install.sh
@@ -14,6 +14,14 @@ echo '++++++++++++++++++++++++++++++++++++++++++++++++++'
 echo ''
 
 ### Start Configuring ###
+# Configure Redis
+if [ "${IX_REDIS:-"true"}" = "true" ]; then
+  echo '# Redis is enabled.'
+  occ_redis_install
+else
+  echo '# Redis is disabled.'
+  occ_redis_remove
+fi
 
 echo ''
 # If Imaginary is enabled, previews are forced enabled

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -1,0 +1,19 @@
+words:
+  - dpkg
+  - gsub
+  - imap
+  - libbz
+  - libc
+  - libde
+  - libfcgi
+  - libheif
+  - libkrb
+  - libmagickcore
+  - libsmbclient
+  - nextcloud
+  - ocrmypdf
+  - pecl
+  - pixbuf
+  - procps
+  - showmanual
+  - smbclient

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -1,4 +1,5 @@
 words:
+  - bugclerk
   - dpkg
   - gsub
   - imap


### PR DESCRIPTION
This is mostly copied from my own nextcloud container that I've been using without issues for more than a year by now.
(https://github.com/stavros-k/containers/tree/master/apps/nextcloud-fpm)

TODO:
- [x] Setup basic renovate to automatically build newer nextcloud versions
- [x] Add nextcloud to the build matrix (GHA pipeline)
- [ ] Optionally publish it under ghcr.io instead of docker.io (This can be done later)
